### PR TITLE
Major Count

### DIFF
--- a/assets/majors.json
+++ b/assets/majors.json
@@ -53,7 +53,7 @@
     },
     {
       "major": "business administration",
-      "aliases": ["bus admin"]
+      "aliases": ["bus admin","business"]
     },
     {
       "major": "chemistry",
@@ -157,7 +157,7 @@
     },
     {
       "major": "materials engineering",
-      "aliases": ["mateng"]
+      "aliases": ["mateng","mate"]
     },
     {
       "major": "mathematics",

--- a/assets/majors.json
+++ b/assets/majors.json
@@ -1,217 +1,221 @@
 {
-  "major":"aerospace engineering",
-  "aliases":["aero"]
-},
-{
-  "major":"agricultural and environmental plant sciences"
-},
-{
-  "major":"agricultural business",
-  "aliases":["agribusiness"]
-},
-{
-  "major":"agricultural communication"
-},
-{
-  "major":"agricultural science"
-},
-{
-  "major":"agricultural systems management"
-},
-{
-  "major":"animal science"
-},
-{
-  "major":"anthropology and geography"
-},
-{
-  "major":"architectural engineering"
-},
-{
-  "major":"architecture",
-  "aliases":["arch"]
-},
-{
-  "major":"art and design"
-},
-{
-  "major":"biochemistry",
-  "aliases":["biochem"]
-},
-{
-  "major":"biological sciences",
-  "aliases":["biology","bio"]
-},
-{
-  "major":"biomedical engineering",
-  "aliases":["biomed","bmed"]
-},
-{
-  "major":"bioresource and agricultural engineering"
-},
-{
-  "major":"business administration",
-  "aliases":["Bus Admin"]
-},
-{
-  "major":"chemistry",
-  "aliases":["chem"]
-},
-{
-  "major":"child development"
-},
-{
-  "major":"city and regional planning"
-},
-{
-  "major":"civil engineering",
-  "aliases":["civil"]
-},
-{
-  "major":"communication studies"
-},
-{
-  "major":"comparative ethnic studies"
-},
-{
-  "major":"computer engineering",
-  "aliases":["comp e", "cpe"]
-},
-{
-  "major":"computer science",
-  "aliases":["cs","compsci","comp sci"]
-},
-{
-  "major":"construction management"
-},
-{
-  "major":"dairy science"
-},
-{
-  "major":"economics",
-  "aliases":["econ"]
-},
-{
-  "major":"electrical engineering",
-  "aliases":["ee"]
-},
-{
-  "major":"english"
-},
-{
-  "major":"environmental earth and soil sciences",
-  "aliases":["environmental earth & soil sciences","earth and soil science"]
-},
-{
-  "major":"environmental engineering"
-},
-{
-  "major":"environmental management and protection"
-},
-{
-  "major":"food science"
-},
-{
-  "major":"forest and fire sciences"
-},
-{
-  "major":"general engineering"
-},
-{
-  "major":"graphic communication"
-},
-{
-  "major":"history"
-},
-{
-  "major":"industrial engineering"
-},
-{
-  "major":"industrial technology and packaging"
-},
-{
-  "major":"interdisciplinary studies"
-},
-{
-  "major":"journalism"
-},
-{
-  "major":"kinesiology"
-},
-{
-  "major":"landscape architecture"
-},
-{
-  "major":"liberal arts and engineering studies"
-},
-{
-  "major":"liberal studies"
-},
-{
-  "major":"manufacturing engineering"
-},
-{
-  "major":"marine sciences"
-},
-{
-  "major":"materials engineering",
-  "aliases":["MatEng"]
-},
-{
-  "major":"mathematics",
-  "aliases":["math"]
-},
-{
-  "major":"mechanical engineering",
-  "aliases":["mech e","mech. e","meche"]
-},
-{
-  "major":"microbiology"
-},
-{
-  "major":"music "
-},
-{
-  "major":"nutrition"
-},
-{
-  "major":"philosophy"
-},
-{
-  "major":"physics"
-},
-{
-  "major":"political science",
-  "aliases":["polisci"]
-},
-{
-  "major":"public health"
-},
-{
-  "major":"psychology",
-  "aliases":["psych"]
-},
-{
-  "major":"recreation, parks, and tourism administration"
-},
-{
-  "major":"sociology"
-},
-{
-  "major":"software engineering",
-  "aliases":["se"]
-},
-{
-  "major":"spanish"
-},
-{
-  "major":"statistics",
-  "aliases":["stats"]
-},
-{
-  "major":"theatre arts",
-  "aliases":["theater arts"]
-},
-{
-  "major":"wine and viticulture"
-},
+  "majors": [
+    {
+      "major": "aerospace engineering",
+      "aliases": ["aero"]
+    },
+    {
+      "major": "agricultural and environmental plant sciences"
+    },
+    {
+      "major": "agricultural business",
+      "aliases": ["agribusiness"]
+    },
+    {
+      "major": "agricultural communication"
+    },
+    {
+      "major": "agricultural science"
+    },
+    {
+      "major": "agricultural systems management"
+    },
+    {
+      "major": "animal science"
+    },
+    {
+      "major": "anthropology and geography"
+    },
+    {
+      "major": "architectural engineering"
+    },
+    {
+      "major": "architecture",
+      "aliases": ["arch"]
+    },
+    {
+      "major": "art and design"
+    },
+    {
+      "major": "biochemistry",
+      "aliases": ["biochem"]
+    },
+    {
+      "major": "biological sciences",
+      "aliases": ["biology", "bio"]
+    },
+    {
+      "major": "biomedical engineering",
+      "aliases": ["biomed", "bmed"]
+    },
+    {
+      "major": "bioresource and agricultural engineering"
+    },
+    {
+      "major": "business administration",
+      "aliases": ["bus admin"]
+    },
+    {
+      "major": "chemistry",
+      "aliases": ["chem"]
+    },
+    {
+      "major": "child development"
+    },
+    {
+      "major": "city and regional planning"
+    },
+    {
+      "major": "civil engineering",
+      "aliases": ["civil"]
+    },
+    {
+      "major": "communication studies"
+    },
+    {
+      "major": "comparative ethnic studies"
+    },
+    {
+      "major": "computer engineering",
+      "aliases": ["comp e", "cpe"]
+    },
+    {
+      "major": "computer science",
+      "aliases": ["cs", "compsci", "comp sci"]
+    },
+    {
+      "major": "construction management"
+    },
+    {
+      "major": "dairy science"
+    },
+    {
+      "major": "economics",
+      "aliases": ["econ"]
+    },
+    {
+      "major": "electrical engineering",
+      "aliases": ["ee"]
+    },
+    {
+      "major": "english"
+    },
+    {
+      "major": "environmental earth and soil sciences",
+      "aliases": ["environmental earth & soil sciences", "earth and soil science"]
+    },
+    {
+      "major": "environmental engineering"
+    },
+    {
+      "major": "environmental management and protection"
+    },
+    {
+      "major": "food science"
+    },
+    {
+      "major": "forest and fire sciences"
+    },
+    {
+      "major": "general engineering"
+    },
+    {
+      "major": "graphic communication"
+    },
+    {
+      "major": "history"
+    },
+    {
+      "major": "industrial engineering"
+    },
+    {
+      "major": "industrial technology and packaging"
+    },
+    {
+      "major": "interdisciplinary studies"
+    },
+    {
+      "major": "journalism"
+    },
+    {
+      "major": "kinesiology"
+    },
+    {
+      "major": "landscape architecture"
+    },
+    {
+      "major": "liberal arts and engineering studies"
+    },
+    {
+      "major": "liberal studies"
+    },
+    {
+      "major": "manufacturing engineering"
+    },
+    {
+      "major": "marine sciences"
+    },
+    {
+      "major": "materials engineering",
+      "aliases": ["mateng"]
+    },
+    {
+      "major": "mathematics",
+      "aliases": ["math"]
+    },
+    {
+      "major": "mechanical engineering",
+      "aliases": ["mech e", "mech. e", "meche"]
+    },
+    {
+      "major": "microbiology"
+    },
+    {
+      "major": "music "
+    },
+    {
+      "major": "nutrition"
+    },
+    {
+      "major": "philosophy"
+    },
+    {
+      "major": "physics"
+    },
+    {
+      "major": "political science",
+      "aliases": ["polisci"]
+    },
+    {
+      "major": "public health"
+    },
+    {
+      "major": "psychology",
+      "aliases": ["psych"]
+    },
+    {
+      "major": "recreation, parks, and tourism administration"
+    },
+    {
+      "major": "sociology"
+    },
+    {
+      "major": "software engineering",
+      "aliases": ["se"]
+    },
+    {
+      "major": "spanish"
+    },
+    {
+      "major": "statistics",
+      "aliases": ["stats"]
+    },
+    {
+      "major": "theatre arts",
+      "aliases": ["theater arts"]
+    },
+    {
+      "major": "wine and viticulture"
+    }
+  ]
+}

--- a/assets/majors.json
+++ b/assets/majors.json
@@ -1,11 +1,13 @@
 {
-  "major":"aerospace engineering"
+  "major":"aerospace engineering",
+  "aliases":["aero"]
 },
 {
   "major":"agricultural and environmental plant sciences"
 },
 {
-  "major":"agricultural business"
+  "major":"agricultural business",
+  "aliases":["agribusiness"]
 },
 {
   "major":"agricultural communication"
@@ -26,28 +28,34 @@
   "major":"architectural engineering"
 },
 {
-  "major":"architecture"
+  "major":"architecture",
+  "aliases":["arch"]
 },
 {
   "major":"art and design"
 },
 {
-  "major":"biochemistry"
+  "major":"biochemistry",
+  "aliases":["biochem"]
 },
 {
-  "major":"biological sciences"
+  "major":"biological sciences",
+  "aliases":["biology","bio"]
 },
 {
-  "major":"biomedical engineering"
+  "major":"biomedical engineering",
+  "aliases":["biomed","bmed"]
 },
 {
   "major":"bioresource and agricultural engineering"
 },
 {
-  "major":"business administration"
+  "major":"business administration",
+  "aliases":["Bus Admin"]
 },
 {
-  "major":"chemistry"
+  "major":"chemistry",
+  "aliases":["chem"]
 },
 {
   "major":"child development"
@@ -56,7 +64,8 @@
   "major":"city and regional planning"
 },
 {
-  "major":"civil engineering"
+  "major":"civil engineering",
+  "aliases":["civil"]
 },
 {
   "major":"communication studies"
@@ -65,10 +74,12 @@
   "major":"comparative ethnic studies"
 },
 {
-  "major":"computer engineering"
+  "major":"computer engineering",
+  "aliases":["comp e", "cpe"]
 },
 {
-  "major":"computer science"
+  "major":"computer science",
+  "aliases":["cs","compsci","comp sci"]
 },
 {
   "major":"construction management"
@@ -77,16 +88,19 @@
   "major":"dairy science"
 },
 {
-  "major":"economics"
+  "major":"economics",
+  "aliases":["econ"]
 },
 {
-  "major":"electrical engineering"
+  "major":"electrical engineering",
+  "aliases":["ee"]
 },
 {
   "major":"english"
 },
 {
-  "major":"environmental earth and soil sciences"
+  "major":"environmental earth and soil sciences",
+  "aliases":["environmental earth & soil sciences","earth and soil science"]
 },
 {
   "major":"environmental engineering"
@@ -140,13 +154,16 @@
   "major":"marine sciences"
 },
 {
-  "major":"materials engineering"
+  "major":"materials engineering",
+  "aliases":["MatEng"]
 },
 {
-  "major":"mathematics"
+  "major":"mathematics",
+  "aliases":["math"]
 },
 {
-  "major":"mechanical engineering"
+  "major":"mechanical engineering",
+  "aliases":["mech e","mech. e","meche"]
 },
 {
   "major":"microbiology"
@@ -164,16 +181,15 @@
   "major":"physics"
 },
 {
-  "major":"physics"
-},
-{
-  "major":"political science"
+  "major":"political science",
+  "aliases":["polisci"]
 },
 {
   "major":"public health"
 },
 {
-  "major":"psychology"
+  "major":"psychology",
+  "aliases":["psych"]
 },
 {
   "major":"recreation, parks, and tourism administration"
@@ -182,16 +198,19 @@
   "major":"sociology"
 },
 {
-  "major":"software engineering"
+  "major":"software engineering",
+  "aliases":["se"]
 },
 {
   "major":"spanish"
 },
 {
-  "major":"statistics"
+  "major":"statistics",
+  "aliases":["stats"]
 },
 {
-  "major":"theatre arts"
+  "major":"theatre arts",
+  "aliases":["theater arts"]
 },
 {
   "major":"wine and viticulture"

--- a/assets/majors.json
+++ b/assets/majors.json
@@ -1,0 +1,198 @@
+{
+  "major":"aerospace engineering"
+},
+{
+  "major":"agricultural and environmental plant sciences"
+},
+{
+  "major":"agricultural business"
+},
+{
+  "major":"agricultural communication"
+},
+{
+  "major":"agricultural science"
+},
+{
+  "major":"agricultural systems management"
+},
+{
+  "major":"animal science"
+},
+{
+  "major":"anthropology and geography"
+},
+{
+  "major":"architectural engineering"
+},
+{
+  "major":"architecture"
+},
+{
+  "major":"art and design"
+},
+{
+  "major":"biochemistry"
+},
+{
+  "major":"biological sciences"
+},
+{
+  "major":"biomedical engineering"
+},
+{
+  "major":"bioresource and agricultural engineering"
+},
+{
+  "major":"business administration"
+},
+{
+  "major":"chemistry"
+},
+{
+  "major":"child development"
+},
+{
+  "major":"city and regional planning"
+},
+{
+  "major":"civil engineering"
+},
+{
+  "major":"communication studies"
+},
+{
+  "major":"comparative ethnic studies"
+},
+{
+  "major":"computer engineering"
+},
+{
+  "major":"computer science"
+},
+{
+  "major":"construction management"
+},
+{
+  "major":"dairy science"
+},
+{
+  "major":"economics"
+},
+{
+  "major":"electrical engineering"
+},
+{
+  "major":"english"
+},
+{
+  "major":"environmental earth and soil sciences"
+},
+{
+  "major":"environmental engineering"
+},
+{
+  "major":"environmental management and protection"
+},
+{
+  "major":"food science"
+},
+{
+  "major":"forest and fire sciences"
+},
+{
+  "major":"general engineering"
+},
+{
+  "major":"graphic communication"
+},
+{
+  "major":"history"
+},
+{
+  "major":"industrial engineering"
+},
+{
+  "major":"industrial technology and packaging"
+},
+{
+  "major":"interdisciplinary studies"
+},
+{
+  "major":"journalism"
+},
+{
+  "major":"kinesiology"
+},
+{
+  "major":"landscape architecture"
+},
+{
+  "major":"liberal arts and engineering studies"
+},
+{
+  "major":"liberal studies"
+},
+{
+  "major":"manufacturing engineering"
+},
+{
+  "major":"marine sciences"
+},
+{
+  "major":"materials engineering"
+},
+{
+  "major":"mathematics"
+},
+{
+  "major":"mechanical engineering"
+},
+{
+  "major":"microbiology"
+},
+{
+  "major":"music "
+},
+{
+  "major":"nutrition"
+},
+{
+  "major":"philosophy"
+},
+{
+  "major":"physics"
+},
+{
+  "major":"physics"
+},
+{
+  "major":"political science"
+},
+{
+  "major":"public health"
+},
+{
+  "major":"psychology"
+},
+{
+  "major":"recreation, parks, and tourism administration"
+},
+{
+  "major":"sociology"
+},
+{
+  "major":"software engineering"
+},
+{
+  "major":"spanish"
+},
+{
+  "major":"statistics"
+},
+{
+  "major":"theatre arts"
+},
+{
+  "major":"wine and viticulture"
+},

--- a/local-bot.py
+++ b/local-bot.py
@@ -224,7 +224,7 @@ async def major_count(ctx):
     data = file.read()
     majors = json.loads(data)
 
-  introductions = ctx.guild.get_channel(971298824779862026) #change
+  introductions = ctx.guild.get_channel(957465271830970389)
   history = await introductions.history(oldest_first=True).flatten()
 
   #create dict of all majors, with counts set to 0
@@ -239,7 +239,7 @@ async def major_count(ctx):
     #filter out off-topic messages
     if all(keyword in message for keyword in keywords):
       if((major := getMajor(message, majors)) is not None):
-        majors_count[major] += 1   
+        majors_count[major] += 1
 
   nonzero_majors = {key.title():val for key, val in sorted(majors_count.items(), key=lambda item: item[1], reverse=True) if(val != 0)}
   desc = ""

--- a/local-bot.py
+++ b/local-bot.py
@@ -26,17 +26,33 @@ def getToken():
 def getID():
   return f"{client.user.id}"
 
-def getMajor(message):
+def getMajor(message, majors):
   line = ""
-  message = str(message)
+
   try:
-    #retrieve 2nd line of message 
+    #retrieve 2nd line of message
     #this method doesn't rely on newline characters, instead using the # in line 1: User#0000
     line = message[message.find("#") + 5:]
-    line = line[:line.find("3")].strip()
-    return line
+    line = line[:line.find("3")].strip().replace('\n',' ')
+
+    #major search
+    if any((maj := major['major']) in line for major in majors['majors']):
+      print(f"Major match: {maj} >> {line}")
+      match = maj
+      return match
+    #alias search
+    elif any([alias in line for alias in major['aliases']] for major in majors['majors'] if(major.get('aliases'))):
+      for major in majors['majors']:
+        if(major.get('aliases')):
+            for alias in major['aliases']:
+              if(alias in line):
+                match = major['major']
+                print(f"Alias match: {match} >> {line}")
+                return match
+    else:
+      return False
   except ValueError:
-    return ""
+    return False
 
 @client.event
 async def on_ready():

--- a/local-bot.py
+++ b/local-bot.py
@@ -178,5 +178,8 @@ async def computer_stats(ctx):
 @client.command()
 async def major_count(ctx):
   print(ctx)
+  out = discord.Embed(color=0x154734, title="Major Count", description=f"test desc")
+  out.set_thumbnail(url=ctx.guild.icon_url)
+  await ctx.send(embed=out)
 
 client.run(getToken())

--- a/local-bot.py
+++ b/local-bot.py
@@ -26,6 +26,18 @@ def getToken():
 def getID():
   return f"{client.user.id}"
 
+def getMajor(message):
+  line = ""
+  message = str(message)
+  try:
+    #retrieve 2nd line of message 
+    #this method doesn't rely on newline characters, instead using the # in line 1: User#0000
+    line = message[message.find("#") + 5:]
+    line = line[:line.find("3")].strip()
+    return line
+  except ValueError:
+    return ""
+
 @client.event
 async def on_ready():
   await client.change_presence(status=discord.Status.online, activity=discord.Game(name="React to my messages in #welcome-and-rules to show others the classes you are in"))

--- a/local-bot.py
+++ b/local-bot.py
@@ -10,10 +10,11 @@ from discord.utils import get
 
 # import os
 import psutil
+
 import json
 import pytz
-
 from datetime import datetime
+
 from constants import *
 
 intents = discord.Intents.all()
@@ -166,7 +167,7 @@ async def on_member_join(member):
   print(guild)
   rules = guild.get_channel(957466979936129044)
   intro = guild.get_channel(957465271830970389)
-  
+
   embed=discord.Embed(color=0xC99117, title="Welcome!", description=f"{member.mention}, Welcome to Cal Poly '26! Tell us a little bit about yourself in {intro.mention} to gain full access!\nUnsure how to do so? Check {rules.mention} for a quick example!")
   embed.set_thumbnail(url="https://media.discordapp.net/attachments/957716447755374673/957761766501257226/Cal-Poly-University-Seal.png")
 
@@ -209,7 +210,12 @@ async def computer_stats(ctx):
   cpu = psutil.cpu_percent(4)
   ram = psutil.virtual_memory()[2]
   disk = psutil.disk_usage("/")[3]
-  await ctx.send(f'CPU Usage: {cpu}%\nRAM Usage: {ram}%\nDisk Usage: {disk}%')
+  out = discord.Embed(color=0x154734)
+  out.add_field(name="CPU Usage", value=f"{cpu}%")
+  out.add_field(name="RAM Usage", value=f"{ram}%")
+  out.add_field(name="Disk Usage", value=f"{disk}%")
+  out.set_footer(text=f"Mustang Bot {getTimeString()}")
+  await ctx.send(embed=out)
   print(f'CPU Usage: {cpu}%\nRAM Usage: {ram}%\nDisk Usage: {disk}%')
 
 @client.command()
@@ -233,7 +239,7 @@ async def major_count(ctx):
     
     #filter out off-topic messages
     if all(keyword in message for keyword in keywords):
-      majors_count[getMajor(message, majors)] += 1   
+      majors_count[getMajor(message, majors)] += 1
 
   nonzero_majors = {key.title():val for key, val in sorted(majors_count.items(), key=lambda item: item[1], reverse=True) if(val != 0)}
   desc = ""

--- a/local-bot.py
+++ b/local-bot.py
@@ -10,11 +10,10 @@ from discord.utils import get
 
 # import os
 import psutil
-
 import json
 import pytz
-from datetime import datetime
 
+from datetime import datetime
 from constants import *
 
 intents = discord.Intents.all()
@@ -54,9 +53,9 @@ def getMajor(message, majors):
                 return match
     else:
       print(f"No major found >> {line}")
-      return False
+      return None
   except ValueError:
-    return False
+    return None
 
 def getTimeString():
   now = datetime.now(pytz.timezone('America/Los_Angeles'))
@@ -239,7 +238,8 @@ async def major_count(ctx):
     
     #filter out off-topic messages
     if all(keyword in message for keyword in keywords):
-      majors_count[getMajor(message, majors)] += 1
+      if((major := getMajor(message, majors)) is not None):
+        majors_count[major] += 1   
 
   nonzero_majors = {key.title():val for key, val in sorted(majors_count.items(), key=lambda item: item[1], reverse=True) if(val != 0)}
   desc = ""

--- a/local-bot.py
+++ b/local-bot.py
@@ -175,4 +175,8 @@ async def computer_stats(ctx):
   await ctx.send(f'CPU Usage: {cpu}%\nRAM Usage: {ram}%\nDisk Usage: {disk}%')
   print(f'CPU Usage: {cpu}%\nRAM Usage: {ram}%\nDisk Usage: {disk}%')
 
+@client.command()
+async def major_count(ctx):
+  print(ctx)
+
 client.run(getToken())

--- a/local-bot.py
+++ b/local-bot.py
@@ -3,10 +3,12 @@
 # python local-bot.py
 
 from email import message
+
 import discord
 from discord.ext import commands
 from discord.utils import get
 
+import json
 from constants import *
 
 # import os
@@ -178,6 +180,11 @@ async def computer_stats(ctx):
 @client.command()
 async def major_count(ctx):
   print(ctx)
+  introductions = ctx.guild.get_channel(971298824779862026)
+  history = await introductions.history(oldest_first=True).flatten()
+  for i in range(len(history)):
+    print(getMajor(history[i].content))
+
   out = discord.Embed(color=0x154734, title="Major Count", description=f"test desc")
   out.set_thumbnail(url=ctx.guild.icon_url)
   await ctx.send(embed=out)

--- a/local-bot.py
+++ b/local-bot.py
@@ -14,6 +14,7 @@ from constants import *
 # import os
 import psutil
 
+from datetime import datetime
 intents = discord.Intents.all()
 client = commands.Bot(command_prefix = '$', intents=intents)
 client.remove_command("$help")
@@ -54,6 +55,9 @@ def getMajor(message, majors):
   except ValueError:
     return False
 
+def getTimeString():
+  now = datetime.now()
+  return now.strftime("%Y/%m%d %H:%M:%S")
 @client.event
 async def on_ready():
   await client.change_presence(status=discord.Status.online, activity=discord.Game(name="React to my messages in #welcome-and-rules to show others the classes you are in"))

--- a/local-bot.py
+++ b/local-bot.py
@@ -10,8 +10,9 @@ from discord.utils import get
 
 # import os
 import psutil
-
 import json
+import pytz
+
 from datetime import datetime
 from constants import *
 
@@ -57,8 +58,8 @@ def getMajor(message, majors):
     return False
 
 def getTimeString():
-  now = datetime.now()
-  return now.strftime("%Y/%m%d %H:%M:%S")
+  now = datetime.now(pytz.timezone('America/Los_Angeles'))
+  return now.strftime("%Y-%m-%d %H:%M:%S")
 
 @client.event
 async def on_ready():
@@ -239,7 +240,7 @@ async def major_count(ctx):
   for major, count in nonzero_majors.items():
     desc += f"{major}: {str(count)}\n"
   out = discord.Embed(color=0x154734, title="Major Count", description=desc)
-  out.set_footer(text=f"Mustang Bot")
+  out.set_footer(text=f"Mustang Bot {getTimeString()}")
   await ctx.send(embed=out)
 
 client.run(getToken())


### PR DESCRIPTION
## Features
### Major Count
Shows the number of server members in each major.

$major_count parses all messages in #introductions and tallies up all of the majors, then sends an embed message of the results, sorted by top major.

All majors offered at Cal Poly are stored in [majors.json](assets/majors.json)
Aliases need to be added manually.

### Computer Stats
Used an embed message to make the stats printout look nicer.

## New Dependencies
- json
- pytz
- datetime

#### maxwell#1844